### PR TITLE
Adds an option to warn players that there is an independent player

### DIFF
--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -152,6 +152,8 @@ CreateConVar("ttt_namechange_bantime", "10")
 
 CreateConVar("ttt_karma_beta", "0", FCVAR_REPLICATED)
 
+CreateConVar("ttt_independent_warn", "1")
+
 -- Drinking game punishments
 CreateConVar("ttt_drinking_death", "drink")
 CreateConVar("ttt_drinking_team_kill", "drink")
@@ -614,6 +616,10 @@ function IncRoundEnd(incr)
 end
 
 local function ShowIndependentWarning()
+	if not GetConVar("ttt_independent_warn"):GetBool() then
+		return
+	end
+
 	local showWarning = false
 
 	for k, v in pairs(player.GetAll()) do

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -613,6 +613,28 @@ function IncRoundEnd(incr)
 	SetRoundEnd(GetGlobalFloat("ttt_round_end", 0) + incr)
 end
 
+local function ShowIndependentWarning()
+	local showWarning = false
+
+	for k, v in pairs(player.GetAll()) do
+		if v:IsKiller() or v:IsJester() or v:IsSwapper() then
+			showWarning = true
+			break
+		end
+	end
+
+	if not showWarning then
+		return
+	end
+
+	local warning = "There is an Independent."
+
+	for k, v in pairs(player.GetAll()) do
+		v:PrintMessage(HUD_PRINTTALK, warning)
+		v:PrintMessage(HUD_PRINTCENTER, warning)
+	end
+end
+
 function TellTraitorsAboutTraitors()
 	local traitornicks = {}
 	local hypnotistnick = {}
@@ -831,7 +853,8 @@ function BeginRound()
 
 	-- Give the StateUpdate messages ample time to arrive
 	timer.Simple(1.5, TellTraitorsAboutTraitors)
-	timer.Simple(2.5, ShowRoundStartPopup)
+	timer.Simple(3, ShowIndependentWarning)
+	timer.Simple(3.5, ShowRoundStartPopup)
 
 	timer.Create("zombieHealthRegen", 0.66, 0, function()
 		for k, v in pairs(player.GetAll()) do

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -859,8 +859,8 @@ function BeginRound()
 
 	-- Give the StateUpdate messages ample time to arrive
 	timer.Simple(1.5, TellTraitorsAboutTraitors)
-	timer.Simple(3, ShowIndependentWarning)
-	timer.Simple(3.5, ShowRoundStartPopup)
+	timer.Simple(2.5, ShowRoundStartPopup)
+	timer.Simple(3.5, ShowIndependentWarning)
 
 	timer.Create("zombieHealthRegen", 0.66, 0, function()
 		for k, v in pairs(player.GetAll()) do

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -152,7 +152,7 @@ CreateConVar("ttt_namechange_bantime", "10")
 
 CreateConVar("ttt_karma_beta", "0", FCVAR_REPLICATED)
 
-CreateConVar("ttt_independent_warn", "0")
+CreateConVar("ttt_independent_warn", "0", FCVAR_NOTIFY)
 
 -- Drinking game punishments
 CreateConVar("ttt_drinking_death", "drink")

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -152,7 +152,7 @@ CreateConVar("ttt_namechange_bantime", "10")
 
 CreateConVar("ttt_karma_beta", "0", FCVAR_REPLICATED)
 
-CreateConVar("ttt_independent_warn", "0", FCVAR_NOTIFY)
+CreateConVar("ttt_independent_warning", "0", FCVAR_NOTIFY)
 
 -- Drinking game punishments
 CreateConVar("ttt_drinking_death", "drink")
@@ -616,7 +616,7 @@ function IncRoundEnd(incr)
 end
 
 local function ShowIndependentWarning()
-	if not GetConVar("ttt_independent_warn"):GetBool() then
+	if not GetConVar("ttt_independent_warning"):GetBool() then
 		return
 	end
 

--- a/gamemodes/terrortown/gamemode/init.lua
+++ b/gamemodes/terrortown/gamemode/init.lua
@@ -152,7 +152,7 @@ CreateConVar("ttt_namechange_bantime", "10")
 
 CreateConVar("ttt_karma_beta", "0", FCVAR_REPLICATED)
 
-CreateConVar("ttt_independent_warn", "1")
+CreateConVar("ttt_independent_warn", "0")
 
 -- Drinking game punishments
 CreateConVar("ttt_drinking_death", "drink")


### PR DESCRIPTION
Adds variable ttt_independent_warn which is '0' by default.

When set to '1', it causes a message to appear on screen at the start of a game stating "There is an Independent.", iff there is a Jester, Killer, or Swapper in the game.

This was a big request from the people that I play with.

It gets displayed after the "There is a glitch", and doesn't disrupt that message.

I've tested this only with bots. I can test it with other people later this week.